### PR TITLE
Handling the projection back onto the reference model

### DIFF
--- a/src/kulprit/projection/projector.py
+++ b/src/kulprit/projection/projector.py
@@ -107,8 +107,7 @@ class Projector:
 
         The projection is defined as the values of the submodel parameters
         minimising the Kullback-Leibler divergence between the submodel
-        and the reference model. This is perform numerically using PyTorch and
-        Adam for the optimisation.
+        and the reference model.
 
         Args:
             term_names (Sequence[str]): Collection of strings containing the

--- a/src/kulprit/projection/projector.py
+++ b/src/kulprit/projection/projector.py
@@ -122,16 +122,6 @@ class Projector:
         # copy term names to avoid mutating the input
         term_names_ = copy.copy(term_names)
 
-        # if projecting onto the reference model, simply return it
-        if set(term_names_) == set(self.model.response_component.common_terms):
-            return SubModel(
-                model=self.model,
-                idata=self.idata,
-                loss=0,
-                size=len(self.model.response_component.common_terms),
-                term_names=term_names_,
-            )
-
         # build restricted bambi model
         new_model = self._build_restricted_model(term_names=term_names_)
 

--- a/src/kulprit/reference.py
+++ b/src/kulprit/reference.py
@@ -82,7 +82,7 @@ class ReferenceModel:
                 log_likelihood={self.model.response_name: ref_log_likelihood},
                 dims={self.model.response_name: [f"{self.model.response_name}_dim_0"]},
             )
-        # extract the elpd point estiamte from the reference model and log it
+        # extract the elpd point estimate from the reference model and log it
         self.ref_loo_elpd = az.loo(idata).elpd_loo
 
     def project(

--- a/src/kulprit/reference.py
+++ b/src/kulprit/reference.py
@@ -72,6 +72,19 @@ class ReferenceModel:
         self.searcher = Searcher(self.projector)
         self.path = None
 
+        # test if reference model idata includes the log-likelihood
+        if "log_likelihood" not in idata.groups():
+            # if not, then compute it
+            ref_log_likelihood = self.projector.compute_model_log_likelihood(
+                model=self.model, idata=self.idata
+            )
+            self.idata.add_groups(
+                log_likelihood={self.model.response_name: ref_log_likelihood},
+                dims={self.model.response_name: [f"{self.model.response_name}_dim_0"]},
+            )
+        # extract the elpd point estiamte from the reference model and log it
+        self.ref_loo_elpd = az.loo(idata).elpd_loo
+
     def project(
         self,
         terms: Union[List[str], Tuple[str], int],

--- a/src/kulprit/search/searcher.py
+++ b/src/kulprit/search/searcher.py
@@ -99,13 +99,6 @@ class Searcher:
 
         # make dictionary of inferencedata objects for each projection
         self.idatas = {k: submodel.idata for k, submodel in self.path.k_submodel.items()}
-        self.idatas.update(
-            {
-                len(
-                    self.projector.model.response_component.common_terms
-                ): self.projector.idata
-            }
-        )
 
         # compare the submodels by some criterion
         comparison = az.compare(


### PR DESCRIPTION
## Description

This PR project submodels back onto the reference model, computes reference model log-likelihood if not done by `pymc`, and logs the reference model LOO-CV elpd for use in plotting.

## Checklist

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
- [ ] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
